### PR TITLE
Leaderboard page now auto-reloads if there are changes to the database

### DIFF
--- a/middleware/getReferrals.js
+++ b/middleware/getReferrals.js
@@ -6,28 +6,28 @@ const api_key = process.env.API_KEY;
 const base = new airtable({ apiKey: api_key }).base('appeqb1CAXVkBv8hN');
 
 module.exports = function(req, res, next) {
-    var referrals = [];
-    const channel = req.params.channel_id;
+	var referrals = [];
+	const channel = req.params.channel_id;
 
-    base('referrals')
-        .select({
-            view: 'Grid view',
-            filterByFormula: `{channel} = "${channel}"`
-        })
-        .eachPage(
-            function page(records, fetchNextPage) {
-                records.forEach(function(record) {
-                    referrals.push(record.fields);
-                });
-                fetchNextPage();
-            },
-            function done(err) {
-                if (err) {
-                    next(err);
-                }
-
-                res.locals.referrals = referrals;
-                next();
-            }
-        );
+	base('referrals')
+		.select({
+			view: 'Grid view',
+			filterByFormula: `{channel} = "${channel}"`
+		})
+		.eachPage(
+			function page(records, fetchNextPage) {
+				records.forEach(function(record) {
+					referrals.push(record.fields);
+				});
+				fetchNextPage();
+			},
+			function done(err) {
+				if (err) {
+					next(err);
+				}
+				req.referrals = referrals;
+				res.locals.referrals = referrals;
+				next();
+			}
+		);
 };

--- a/middleware/processLeaderboard.js
+++ b/middleware/processLeaderboard.js
@@ -1,33 +1,34 @@
-function addOrIncrementReferrer(referral, leaderboard){
-    var found = false;
-    if (leaderboard.length > 0) {
-        for (var i=0; i < leaderboard.length; i++) {
-            if (leaderboard[i].referrer === referral.referrer) {
-                leaderboard[i].views++;
-                found = true;
-            }
-        }
-    }
-    if (!found) {
-        leaderboard.push({referrer: referral.referrer, views: 1});
-    }
+function addOrIncrementReferrer(referral, leaderboard) {
+	var found = false;
+	if (leaderboard.length > 0) {
+		for (var i = 0; i < leaderboard.length; i++) {
+			if (leaderboard[i].referrer === referral.referrer) {
+				leaderboard[i].views++;
+				found = true;
+			}
+		}
+	}
+	if (!found) {
+		leaderboard.push({ referrer: referral.referrer, views: 1 });
+	}
 
-    return leaderboard;
-
+	return leaderboard;
 }
 
 module.exports = function(req, res, next) {
-    var referrals = res.locals.referrals;
-    var settings = res.locals.leaderboardSettings;
+	var referrals =
+		typeof req.referrals != undefined ? req.referrals : res.locals.referrals;
+	var settings = res.locals.leaderboardSettings;
 
-    leaderboard = [];
+	leaderboard = [];
 
-    referrals.forEach( (referral) => {
-        leaderboard = addOrIncrementReferrer(referral, leaderboard);
-    });
+	referrals.forEach(referral => {
+		leaderboard = addOrIncrementReferrer(referral, leaderboard);
+	});
 
-    leaderboard.sort((a, b) => (a.views < b.views) ? 1 : -1);
+	leaderboard.sort((a, b) => (a.views < b.views ? 1 : -1));
 
-    res.locals.leaderboard = leaderboard;
-    next();
+	req.leaderboard = leaderboard;
+	res.locals.leaderboard = leaderboard;
+	next();
 };

--- a/public/js/getUpdate.js
+++ b/public/js/getUpdate.js
@@ -1,0 +1,12 @@
+const { href, protocol, hostname, port, pathname } = window.location;
+const newBoard = document.getElementById('hidden');
+url = `${protocol}//${hostname}:${port}/api/v1`;
+axios.defaults.baseURL = url;
+
+window.setInterval(() => {
+	axios.get(pathname).then(res => {
+		if (JSON.stringify(res.data) != newBoard.innerHTML) {
+			window.location.reload(true);
+		}
+	});
+}, 5000);

--- a/server.js
+++ b/server.js
@@ -12,9 +12,9 @@ const requestIP = require('./middleware/requestIP');
 const excludeFavicon = require('./middleware/exludeFavicon');
 require('dotenv').config();
 
-function errorHandler (err, req, res, next) {
-    console.error(err.stack);
-    res.status(500).send('Something broke!');
+function errorHandler(err, req, res, next) {
+	console.error(err.stack);
+	res.status(500).send('Something broke!');
 }
 
 app.set('views', './views');
@@ -25,21 +25,41 @@ app.use(excludeFavicon);
 
 // Root Route
 app.get('/', (req, res) => {
-    res.send('API is running.');
+	res.send('API is running.');
 });
 
 // Admin Routes
-app.get('/admin/:channel_id', getLeaderboardSettings, getReferrals, processLeaderboard, (req, res) => {
-    res.render('admin');
-});
+app.get(
+	'/admin/:channel_id',
+	getLeaderboardSettings,
+	getReferrals,
+	processLeaderboard,
+	(req, res) => {
+		res.render('admin');
+	}
+);
 app.get('/admin/:channel_id/reset', getLeaderboardSettings, resetLeaderboard);
-app.post('/admin/:channel_id/set-theme/:theme', getLeaderboardSettings, setTheme);
+app.post(
+	'/admin/:channel_id/set-theme/:theme',
+	getLeaderboardSettings,
+	setTheme
+);
 app.get('/admin', (req, res) => {
-    res.send('Thou shalt not pass!');
+	res.send('Thou shalt not pass!');
 });
 
-app.get('/:channel_id', getLeaderboardSettings, getReferrals, processLeaderboard, (req, res) => {
-    res.render('index');
+app.get(
+	'/:channel_id',
+	getLeaderboardSettings,
+	getReferrals,
+	processLeaderboard,
+	(req, res) => {
+		res.render('index');
+	}
+);
+
+app.get('/api/v1/:channel_id', getReferrals, processLeaderboard, (req, res) => {
+	res.json(req.leaderboard);
 });
 
 // Referral Route

--- a/views/index.pug
+++ b/views/index.pug
@@ -15,6 +15,7 @@ html(lang='en')
 
   body
     block content
+    div(id="hidden", style="display: none;")= JSON.stringify(leaderboard)
     div(class='app')
         - if (typeof(leaderboard) !== 'undefined'){
             div(class='leaderboard ' + leaderboardSettings.theme)
@@ -27,3 +28,5 @@ html(lang='en')
                             td= row.referrer
                             td= row.views
         -}
+    script(src="https://unpkg.com/axios/dist/axios.min.js", type="text/javascript")
+    script(src="/public/js/getUpdate.js")


### PR DESCRIPTION
Built an API route for getting the leaderboard.
Wrote a short script that saves the current state on page load, then compares that to the data from the API route every 5 seconds.